### PR TITLE
feat: 회원가입 / 닉네임 변경 API 구현 완료

### DIFF
--- a/src/main/java/dxw/soup/backend/soupserver/domain/question/exception/QuestionErrorCode.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/question/exception/QuestionErrorCode.java
@@ -1,0 +1,16 @@
+package dxw.soup.backend.soupserver.domain.question.exception;
+
+import dxw.soup.backend.soupserver.global.common.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionErrorCode implements ErrorCode {
+    SUBJECT_UNIT_NOT_FOUND("단원 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/dxw/soup/backend/soupserver/domain/question/repository/SubjectUnitRepository.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/question/repository/SubjectUnitRepository.java
@@ -1,0 +1,7 @@
+package dxw.soup.backend.soupserver.domain.question.repository;
+
+import dxw.soup.backend.soupserver.domain.question.entity.SubjectUnit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubjectUnitRepository extends JpaRepository<SubjectUnit, Long> {
+}

--- a/src/main/java/dxw/soup/backend/soupserver/domain/question/service/QuestionService.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/question/service/QuestionService.java
@@ -1,0 +1,19 @@
+package dxw.soup.backend.soupserver.domain.question.service;
+
+import dxw.soup.backend.soupserver.domain.question.entity.SubjectUnit;
+import dxw.soup.backend.soupserver.domain.question.exception.QuestionErrorCode;
+import dxw.soup.backend.soupserver.domain.question.repository.SubjectUnitRepository;
+import dxw.soup.backend.soupserver.global.common.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+    private final SubjectUnitRepository subjectUnitRepository;
+
+    public SubjectUnit findSubjectUnitById(Long subjectUnitId) {
+        return subjectUnitRepository.findById(subjectUnitId)
+                .orElseThrow(() -> new ApiException(QuestionErrorCode.SUBJECT_UNIT_NOT_FOUND));
+    }
+}

--- a/src/main/java/dxw/soup/backend/soupserver/domain/user/controller/UserController.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/user/controller/UserController.java
@@ -1,0 +1,37 @@
+package dxw.soup.backend.soupserver.domain.user.controller;
+
+import dxw.soup.backend.soupserver.domain.user.dto.request.UserNicknameUpdateRequest;
+import dxw.soup.backend.soupserver.domain.user.dto.request.UserSignupRequest;
+import dxw.soup.backend.soupserver.domain.user.facade.UserFacade;
+import dxw.soup.backend.soupserver.global.common.annotation.RestApiController;
+import dxw.soup.backend.soupserver.global.common.auth.UserPrincipal;
+import dxw.soup.backend.soupserver.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RequiredArgsConstructor
+@RestApiController("v1/users")
+public class UserController {
+    private final UserFacade userFacade;
+
+    @PostMapping("/sign-up")
+    public ApiResponse<?> signUp(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody UserSignupRequest request
+    ) {
+        userFacade.signUp(principal.getUserId(), request);
+        return ApiResponse.ok();
+    }
+
+    @PatchMapping("/me/nickname")
+    public ApiResponse<?> updateNickname(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody UserNicknameUpdateRequest request
+    ) {
+        userFacade.updateNickname(principal.getUserId(), request);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/dxw/soup/backend/soupserver/domain/user/dto/request/UserNicknameUpdateRequest.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/user/dto/request/UserNicknameUpdateRequest.java
@@ -1,0 +1,6 @@
+package dxw.soup.backend.soupserver.domain.user.dto.request;
+
+public record UserNicknameUpdateRequest(
+        String nickname
+) {
+}

--- a/src/main/java/dxw/soup/backend/soupserver/domain/user/dto/request/UserSignupRequest.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/user/dto/request/UserSignupRequest.java
@@ -1,0 +1,13 @@
+package dxw.soup.backend.soupserver.domain.user.dto.request;
+
+import dxw.soup.backend.soupserver.domain.user.enums.Grade;
+import java.util.List;
+
+public record UserSignupRequest(
+        Grade grade,
+        Integer term,
+        Long lastSubjectUnitId,
+        Double studyHours,
+        List<String> workbooks
+) {
+}

--- a/src/main/java/dxw/soup/backend/soupserver/domain/user/entity/User.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/user/entity/User.java
@@ -50,20 +50,35 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "last_subject_unit_id")
     private SubjectUnit lastSubjectUnit;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Grade grade;
 
-    @Column(nullable = false)
     private Integer term;
 
-    @Column(name = "study_hours", nullable = false)
+    @Column(name = "study_hours")
     private Double studyHours;
 
     //콤마(,)로 구분
     private String workbooks;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Soup soup;
+
+    public void register(
+            Grade grade,
+            Integer term,
+            SubjectUnit lastSubjectUnit,
+            Double studyHours,
+            String workbooks
+    ) {
+        this.grade = grade;
+        this.term = term;
+        this.lastSubjectUnit = lastSubjectUnit;
+        this.studyHours = studyHours;
+        this.workbooks = workbooks;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/dxw/soup/backend/soupserver/domain/user/enums/Grade.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/user/enums/Grade.java
@@ -1,7 +1,7 @@
 package dxw.soup.backend.soupserver.domain.user.enums;
 
 public enum Grade {
-    ONE, TWO, THREE;
+    M1, M2, M3;
 
     public String getGradeText() {
         return (ordinal() + 1) + "학년";

--- a/src/main/java/dxw/soup/backend/soupserver/domain/user/facade/UserFacade.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/user/facade/UserFacade.java
@@ -1,0 +1,36 @@
+package dxw.soup.backend.soupserver.domain.user.facade;
+
+import dxw.soup.backend.soupserver.domain.question.entity.SubjectUnit;
+import dxw.soup.backend.soupserver.domain.question.service.QuestionService;
+import dxw.soup.backend.soupserver.domain.user.dto.request.UserNicknameUpdateRequest;
+import dxw.soup.backend.soupserver.domain.user.dto.request.UserSignupRequest;
+import dxw.soup.backend.soupserver.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+    private final UserService userService;
+    private final QuestionService questionService;
+
+    @Transactional
+    public void signUp(Long userId, UserSignupRequest request) {
+        SubjectUnit lastSubjectUnit = questionService.findSubjectUnitById(request.lastSubjectUnitId());
+
+        userService.signUp(
+                userId,
+                request.grade(),
+                request.term(),
+                lastSubjectUnit,
+                request.studyHours(),
+                request.workbooks()
+        );
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, UserNicknameUpdateRequest request) {
+        userService.updateNickname(userId, request.nickname());
+    }
+}

--- a/src/main/java/dxw/soup/backend/soupserver/domain/user/service/UserService.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/user/service/UserService.java
@@ -1,0 +1,35 @@
+package dxw.soup.backend.soupserver.domain.user.service;
+
+import dxw.soup.backend.soupserver.domain.question.entity.SubjectUnit;
+import dxw.soup.backend.soupserver.domain.user.entity.User;
+import dxw.soup.backend.soupserver.domain.user.enums.Grade;
+import dxw.soup.backend.soupserver.domain.user.exception.UserErrorCode;
+import dxw.soup.backend.soupserver.domain.user.repository.UserRepository;
+import dxw.soup.backend.soupserver.global.common.exception.ApiException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public void signUp(Long userId, Grade grade, Integer term, SubjectUnit lastSubjectUnit, Double studyHours, List<String> workbooks) {
+        User user = findById(userId);
+        String workbookText = String.join(",", workbooks);
+
+        user.register(grade, term, lastSubjectUnit, studyHours, workbookText);
+    }
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public void updateNickname(Long userId, String nickname) {
+        User user = findById(userId);
+
+        user.updateNickname(nickname);
+    }
+}

--- a/src/main/java/dxw/soup/backend/soupserver/global/common/dto/ApiResponse.java
+++ b/src/main/java/dxw/soup/backend/soupserver/global/common/dto/ApiResponse.java
@@ -13,6 +13,14 @@ public record ApiResponse<T>(
         @JsonInclude(value = JsonInclude.Include.NON_NULL)
         T data
 ) {
+    public static ApiResponse<?> ok() {
+        return success(SuccessCode.OK);
+    }
+
+    public static <T> ApiResponse<T> ok(final T data) {
+        return success(SuccessCode.OK, data);
+    }
+
     public static <T> ApiResponse<T> success(final SuccessCode successCode) {
         return new ApiResponse<>(successCode.getStatus().value(), SuccessCode.CODE, SuccessCode.MESSAGE, null);
     }

--- a/src/main/java/dxw/soup/backend/soupserver/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dxw/soup/backend/soupserver/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package dxw.soup.backend.soupserver.global.common.exception;
+
+import dxw.soup.backend.soupserver.global.common.code.ErrorCode;
+import dxw.soup.backend.soupserver.global.common.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ApiException.class)
+    public ApiResponse<?> handleApiException(ApiException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+
+        log.error("에러 발생: ({}) {}", errorCode.name(), errorCode.getMessage());
+
+        return ApiResponse.error(errorCode);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#7 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원가입 API 구현 ([POST] /v1/users/sign-up)
  - 첫 소셜 로그인 시 회원가입 때 받는 추가 정보를 null로 넣기 때문에 추가 정보 컬럼들을 not-null에서 nullable로 수정하였습니다. 

- 닉네임 변경 API 구현 ([PATCH] /v1/users/me/nickname)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
