### PR TITLE
feat: 플래너 아이템 전체 완료 시 불꽃 상태 자동 업데이트

### DIFF
--- a/src/main/java/dxw/soup/backend/soupserver/domain/planner/entity/Planner.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/planner/entity/Planner.java
@@ -48,4 +48,8 @@ public class Planner extends BaseTimeEntity {
     public void updateFeedback(PlannerFeedback feedback) {
         this.feedback = feedback;
     }
+
+    public void updateFlame(boolean flame) {
+        this.flame = flame;
+    }
 }

--- a/src/main/java/dxw/soup/backend/soupserver/domain/planner/facade/PlannerFacade.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/planner/facade/PlannerFacade.java
@@ -76,6 +76,12 @@ public class PlannerFacade {
         validatePlannerItemOwner(user, plannerItem);
 
         plannerService.updateItemCheck(plannerItem, checked);
+
+        Planner planner = plannerItem.getPlanner();
+        List<PlannerItem> allItems = plannerService.findItemsByPlannerId(planner.getId());
+        boolean allChecked = allItems.stream().allMatch(PlannerItem::isChecked);
+
+        plannerService.updateFlame(planner, allChecked);
     }
 
     public PlannerResponse getPlannerByDate(Long userId, LocalDate date) {

--- a/src/main/java/dxw/soup/backend/soupserver/domain/planner/service/PlannerService.java
+++ b/src/main/java/dxw/soup/backend/soupserver/domain/planner/service/PlannerService.java
@@ -83,4 +83,9 @@ public class PlannerService {
     public void updateItemCheck(PlannerItem plannerItem, boolean checked) {
         plannerItem.updateChecked(checked);
     }
+
+    @Transactional
+    public void updateFlame(Planner planner, boolean flame) {
+        planner.updateFlame(flame);
+    }
 }

--- a/src/main/resources/http/test.http
+++ b/src/main/resources/http/test.http
@@ -7,11 +7,11 @@ Content-Type: application/json
 Authorization: Bearer
 
 {
-  "grade": "M1",
-  "term": 1,
-  "lastSubjectUnitId": 1,
-  "studyHours": 1.0,
-  "workbooks": ["쎈 중등수학 1-1"]
+"grade": "M1",
+"term": 1,
+"lastSubjectUnitId": 1,
+"studyHours": 1.0,
+"workbooks": ["쎈 중등수학 1-1"]
 }
 
 ### 닉네임 변경
@@ -20,7 +20,7 @@ Content-Type: application/json
 Authorization: Bearer
 
 {
-  "nickname": "정다은1"
+  "nickname": "정다은"
 }
 
 ### 유저 정보 조회
@@ -39,7 +39,7 @@ Authorization: Bearer
 ### 플래너 생성
 POST http://localhost:8080/v1/planners
 Content-Type: application/json
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1NUBrb29rbWluLmFjLmtyIiwiaWF0IjoxNzU3NjQyNjI0LCJleHAiOjE3NjAyMzQ2MjQsInN1YiI6InRuYWxzNjU1QG5hdmVyLmNvbSIsImlkIjoxfQ.RLByL00bsRDeT1LwkGlZc9qtLPBdrtLTjFJlj7zqkAc
+Authorization: Bearer
 
 {
   "date": "2025-09-28"
@@ -47,12 +47,12 @@ Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1N
 
 ### 플래너 삭제
 DELETE http://localhost:8080/v1/planners/1
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1NUBrb29rbWluLmFjLmtyIiwiaWF0IjoxNzU3NjQyNjI0LCJleHAiOjE3NjAyMzQ2MjQsInN1YiI6InRuYWxzNjU1QG5hdmVyLmNvbSIsImlkIjoxfQ.RLByL00bsRDeT1LwkGlZc9qtLPBdrtLTjFJlj7zqkAc
+Authorization: Bearer
 
 ### 플래너 피드백 업데이트
 PATCH http://localhost:8080/v1/planners/1/feedback
 Content-Type: application/json
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1NUBrb29rbWluLmFjLmtyIiwiaWF0IjoxNzU3NjQyNjI0LCJleHAiOjE3NjAyMzQ2MjQsInN1YiI6InRuYWxzNjU1QG5hdmVyLmNvbSIsImlkIjoxfQ.RLByL00bsRDeT1LwkGlZc9qtLPBdrtLTjFJlj7zqkAc
+Authorization: Bearer
 
 {
   "feedback": "GOOD"
@@ -61,7 +61,7 @@ Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1N
 ### 플래너 아이템 체크 상태 업데이트
 PATCH http://localhost:8080/v1/planners/items/1/check
 Content-Type: application/json
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1NUBrb29rbWluLmFjLmtyIiwiaWF0IjoxNzU3NjQyNjI0LCJleHAiOjE3NjAyMzQ2MjQsInN1YiI6InRuYWxzNjU1QG5hdmVyLmNvbSIsImlkIjoxfQ.RLByL00bsRDeT1LwkGlZc9qtLPBdrtLTjFJlj7zqkAc
+Authorization: Bearer
 
 {
   "checked": true
@@ -69,8 +69,8 @@ Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1N
 
 ### 특정 날짜 플래너 조회
 GET http://localhost:8080/v1/planners?date=2025-09-28
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1NUBrb29rbWluLmFjLmtyIiwiaWF0IjoxNzU3NjQyNjI0LCJleHAiOjE3NjAyMzQ2MjQsInN1YiI6InRuYWxzNjU1QG5hdmVyLmNvbSIsImlkIjoxfQ.RLByL00bsRDeT1LwkGlZc9qtLPBdrtLTjFJlj7zqkAc
+Authorization: Bearer
 
 ### 플래너 불꽃 조회 (기간별)
 GET http://localhost:8080/v1/planners/flames?startDate=2025-09-01&endDate=2025-09-30
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0bmFsczY1NUBrb29rbWluLmFjLmtyIiwiaWF0IjoxNzU3NjQyNjI0LCJleHAiOjE3NjAyMzQ2MjQsInN1YiI6InRuYWxzNjU1QG5hdmVyLmNvbSIsImlkIjoxfQ.RLByL00bsRDeT1LwkGlZc9qtLPBdrtLTjFJlj7zqkAc
+Authorization: Bearer


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #20 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 플래너 아이템 체크 시, 모든 항목이 완료되면 플래너의 불꽃(Flame) 상태를 자동으로 업데이트하도록 기능 추가
- Planner, PlannerService, PlannerFacade에 관련 메서드 및 로직 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
